### PR TITLE
Fixed issue with getProject returning wrong project

### DIFF
--- a/pyral/restapi.py
+++ b/pyral/restapi.py
@@ -433,7 +433,7 @@ class Rally(object):
         hits = [(proj,ref) for proj,ref in projs if str(proj) == str(name)]
         if not hits:
             return None
-        tp = projs[0]
+        tp = hits[0]
         tp_ref = tp[1]
         return _createShellInstance(context, 'Project', name, tp_ref)
         


### PR DESCRIPTION
The function getProject should return the project you asked for when you pass the name parameter instead it returns the first element the projects tuple on the whole workspace.