### PR TITLE
Change "deadline" option for ping from 2 seconds to 10 seconds

### DIFF
--- a/pyral/context.py
+++ b/pyral/context.py
@@ -708,7 +708,7 @@ class Pinger(object):
     """
     PING_COMMAND = {'Darwin'  : ["ping", "-o", "-c", "2", "-t", "2"],
                     'Unix'    : ["ping",       "-c", "2", "-w", "2"],
-                    'Linux'   : ["ping",       "-c", "2", "-w", "2"],
+                    'Linux'   : ["ping",       "-c", "2", "-w", "10"],
                     'Windows' : ["ping",       "-n", "2", "-w", "2"],
                     'Cygwin'  : ["ping",       "-n", "2", "-w", "2"]
                    }


### PR DESCRIPTION
![screen shot 2015-07-01 at 5 40 44 pm](https://cloud.githubusercontent.com/assets/8131736/8467821/5f79aa12-2018-11e5-80f5-6dfa94460176.png)
As shown above, when I run my rally test automation framework with latest pyral 1.1.1, it shows errors related to ping. As I check Pinger.ping() in context.py, the "-w" option of ping command is set to 2, which is too small for my host - I am running my framework on Debian 7.8 with linux kernel 3.2.0. Thus I am changing it to larger value - 10, this is needed for hosts with bad network connections. Not sure why the value was set to 2 in the first place and the value may need adjust for other operation systems as well.