### PR TITLE
Capitalization of entity-type json key for PortfolioItem get requests

### DIFF
--- a/pyral/entity.py
+++ b/pyral/entity.py
@@ -102,9 +102,10 @@ class Persistable(object):
             raise Exception('Unsupported attempt to retrieve context attribute')
 
         rallyEntityTypeName = self.__class__.__name__
-        entity_path, oid = self._ref.split(SLM_WS_VER)[-1].rsplit('/', 1)
-        if entity_path.startswith('portfolioitem/'):
-            rallyEntityTypeName = entity_path.split('/')[-1].capitalize()
+        PORTFOLIO_PREFIX = 'PortfolioItem_'
+        if rallyEntityTypeName.startswith(PORTFOLIO_PREFIX):
+            rallyEntityTypeName = re.sub(PORTFOLIO_PREFIX, '',
+                                         rallyEntityTypeName)
 
         faultTrigger = "getattr fault detected on %s instance for attribute: %s  (hydrated? %s)" % \
                        (rallyEntityTypeName, name, self._hydrated)


### PR DESCRIPTION
When requesting portfolio items, the key used in the rest response is odd. The
existing code to munge it was not preserving necessary capitalization, and so
get requests using entity-types of PortfolioItem/MarketRequirement,
PortfolioItem/ProductRequirement, and PortfolioItem/ReleaseRequirement were
failing. This small fix fixes that.
