### PR TITLE
Allow disabling the server ping reachability verification

### DIFF
--- a/pyral/context.py
+++ b/pyral/context.py
@@ -90,11 +90,12 @@ class RallyContext(object):
 
 class RallyContextHelper(object):
 
-    def __init__(self, agent, server, user, password):
+    def __init__(self, agent, server, user, password, ping=True):
         self.agent  = agent
         self.server = server
         self.user   = user
         self.password = password
+        self.ping   = ping
 
         # capture this user's User, UserProfile, Subscription records to extract 
         # the workspaces and projects this user has access to (and their defaults)
@@ -143,11 +144,12 @@ class RallyContextHelper(object):
             proxy_host, proxy_port = proxy.split(':')
         target_host = proxy_host or server
 
-        reachable, problem = Pinger.ping(target_host)
-        if not reachable:
-             if not problem:
-                 problem = "host: '%s' non-existent or unreachable"  % target_host
-             raise RallyRESTAPIError(problem)
+        if self.ping:
+            reachable, problem = Pinger.ping(target_host)
+            if not reachable:
+                 if not problem:
+                     problem = "host: '%s' non-existent or unreachable"  % target_host
+                 raise RallyRESTAPIError(problem)
 
         # note the use of the _disableAugments keyword arg in the call
         user_name_query = 'UserName = "%s"' % self.user

--- a/pyral/restapi.py
+++ b/pyral/restapi.py
@@ -174,7 +174,7 @@ class Rally(object):
     MAX_ATTACHMENT_SIZE = 5000000  # approx 5MB 
 
     def __init__(self, server=SERVER, user=None, password=None, apikey=None,
-                       version=WS_API_VERSION, warn=True, **kwargs):
+                       version=WS_API_VERSION, warn=True, ping=True, **kwargs):
         self.server   = server 
         self.user     = user     or USER_NAME
         self.password = password or PASSWORD
@@ -189,6 +189,7 @@ class Rally(object):
         self._logDest    = None
         self._logAttrGet = False
         self._warn       = warn
+        self._ping       = ping
         config = {}
         if kwargs and 'debug' in kwargs and kwargs.get('debug', False):
             config['verbose'] = sys.stdout
@@ -223,7 +224,8 @@ class Rally(object):
         
         global _rallyCache
 
-        self.contextHelper = RallyContextHelper(self, self.server, self.user, self.password or self.apikey)
+        self.contextHelper = RallyContextHelper(self, self.server, self.user, self.password or self.apikey,
+                                                ping=self._ping)
         _rallyCache[self.contextHelper.context] = {'rally' : self }
         self.contextHelper.check(self.server)
 


### PR DESCRIPTION
On networks with ICMP echo disabled it wasn't possible to connect
to the server due to the failing reachability test. This commit allows
disabling the ping verification via a `ping` parameter to `Rally` / `RallyContextHelper`.