### PR TITLE
Fixed KeyError in RallyRESTResponse.__repr__()

### DIFF
--- a/pyral/rallyresp.py
+++ b/pyral/rallyresp.py
@@ -375,7 +375,7 @@ class RallyRESTResponse(object):
                 blurb = self.warnings[0]
             else:
                 blurb = "%sResult TotalResultCount: %d  Results: %s" % \
-                         (self.request_type, self.resultCount, self.content['Results'])
+                         (self.request_type, self.resultCount, self.content['QueryResult']['Results'])
             return "%s %s" % (self.status_code, blurb)
 
 ##################################################################################################


### PR DESCRIPTION
Fixed RallyRESTResponse.__repr__() so it doesn't raise a KeyError on a response to a query that returned no results.