### PR TITLE
fix authentication with On-Premise LDAP User Name

### DIFF
--- a/pyral/context.py
+++ b/pyral/context.py
@@ -206,7 +206,7 @@ class RallyContextHelper(object):
 
     def _getUserInfo(self):
         # note the use of the _disableAugments keyword arg in the call
-        user_name_query = 'UserName = "%s"' % self.user
+        user_name_query = '((UserName = "%s") OR (OnpremLdapUsername = "%s"))' % (self.user, self.user)
 ##
 ##        print("user_name_query: |%s|" % user_name_query)
 ##


### PR DESCRIPTION
The toolkit won't work in my scenario because we run an on-premise instance and use the LdapUsername to login. Just extended the query on _getUserInfo to make it work in this case too. 