### PR TITLE
set the size of connection pool.

### DIFF
--- a/pyral/restapi.py
+++ b/pyral/restapi.py
@@ -328,6 +328,8 @@ class Rally(object):
         """
         return self.contextHelper._inflated
 
+    def setSessionAdapter(self, adapter : requests.adapters.HTTPAdapter):
+        self.session.mount('https://', adapter)
 
     def serviceURL(self):
         """


### PR DESCRIPTION
Hello!
Currently if I get all items from Rally and then I am trying to process these items in more than 10 threads I have an error: connection pool exhausted.
By default the connection pool size equals to 10. 
To be able to process items in more than 10 threads we need to increase the connection pool size. It can be done via requests.adapters.HTTPAdapter. That is why I create a method, which accepts an object of this class and set the connection pool with this object.
This method can be used like this:

import requests
# init self.rally with Rally(parameters here)
self.rally.setSessionAdapter(requests.adapters.HTTPAdapter(pool_connections=50, pool_maxsize=50))
