### PR TITLE
Increase MAX_ITEMS to 10M

### DIFF
--- a/pyral/config.py
+++ b/pyral/config.py
@@ -29,7 +29,7 @@ PASSWORD  = "G3ronim0!"
 START_INDEX  = 1
 KILO_PAGESIZE= 1000
 MAX_PAGESIZE = 2000
-MAX_ITEMS    = 1000000  # a million seems an eminently reasonable limit ...
+MAX_ITEMS    = 10000000
 DEFAULT_SESSION_TIMEOUT = 10   # in seconds
 
 RALLY_REST_HEADERS = \


### PR DESCRIPTION
For https://github.com/RallyTools/RallyRestToolkitForPython/issues/195
It's easy for some resources to have more than 1M records (e.g. ConversationPost). Increase MAX_SIZE to 10M.